### PR TITLE
remove attaching keypair step

### DIFF
--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -9,15 +9,6 @@ class ContainersController < ApplicationController
     end
     response = container.launch
 
-    # Assign key pair if it's specified
-    unless @key_pair_name.blank?
-      # Give time for the container to start
-      # TODO: @giosakti should find more predictable way
-      sleep(5.seconds)
-      key_pair = KeyPair.find_by!(name: @key_pair_name)
-      response = Lxd.attach_public_key(@lxd_host_ipaddress, @container_hostname, key_pair.public_key)
-    end
-
     return render json: response, status: :created if response[:success] == 'true'
     render json: response, status: :internal_server_error
   end


### PR DESCRIPTION
This particular step of attaching keypair after container provisioning are causing us trouble due to the unpredictability (asynchronous) nature of container provisioning. We will have to rely on profile instead.

For now we can make do by modifying our cookbook attributes so that a predefined key is inserted properly in the profile. But later we should have profile management built-in in sauron for greater flexibility.