### PR TITLE
Handle asynchronous container operation properly

### DIFF
--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -35,7 +35,7 @@ class ContainersController < ApplicationController
         format.html
         format.json
       else
-        format.json{ render :json => @container, :status => 404 }
+        format.json{ render :json => @container, :status => 500 }
       end
     end
   end

--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -31,8 +31,12 @@ class ContainersController < ApplicationController
   def show
     @container = Lxd.show_container(params[:container_hostname])
     respond_to do |format|
-      format.html
-      format.json
+      if @container[:success]
+        format.html
+        format.json
+      else
+        format.json{ render :json => @container, :status => 404 }
+      end
     end
   end
 

--- a/app/jobs/start_container.rb
+++ b/app/jobs/start_container.rb
@@ -9,9 +9,16 @@ class StartContainer
   def perform(container_name)
     container = client.container(container_name)
     start_interval = Time.now - container[:created_at]
+    container_status = container[:status]
+    count = 0
     if start_interval > Figaro.env.WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS.to_i
-      if container[:status] != "Running"
-        client.start_container(container_name)
+      while container_status != "Running" || count == Figaro.env.MAX_RETRY.to_i
+        sleep(Figaro.env.WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS.to_i)
+        res = client.start_container(container_name)
+        container_detail = client.container_state(container_name)
+        container_status = container_detail[:status]
+        count += 1
+        res
       end
     else
       raise Exception.new("Container #{container_name} is still being created")

--- a/app/jobs/start_container.rb
+++ b/app/jobs/start_container.rb
@@ -1,28 +1,7 @@
 class StartContainer
   include Sidekiq::Worker
-  sidekiq_options :retry => 5
-
-  sidekiq_retry_in do |count|
-    count + 1
-  end
-
   def perform(container_name)
-    container = client.container(container_name)
-    start_interval = Time.now - container[:created_at]
-    container_status = container[:status]
-    count = 0
-    if start_interval > Figaro.env.WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS.to_i
-      while container_status != "Running" || count == Figaro.env.MAX_RETRY.to_i
-        sleep(Figaro.env.WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS.to_i)
-        res = client.start_container(container_name)
-        container_detail = client.container_state(container_name)
-        container_status = container_detail[:status]
-        count += 1
-        res
-      end
-    else
-      raise Exception.new("Container #{container_name} is still being created")
-    end
+    client.start_container(container_name)
   end
 
   def client

--- a/app/views/containers/show.json.jbuilder
+++ b/app/views/containers/show.json.jbuilder
@@ -1,10 +1,10 @@
-json.success true
+json.success @container[:success]
 json.data do
-  json.hostname @container.container_hostname
-  json.ipaddress @container.ipaddress
-  json.image @container.image
-  json.status @container.status
-  json.created_at @container.created_at
-  json.lxc_profiles @container.lxc_profiles
+  json.hostname @container[:data].container_hostname
+  json.status @container[:data].status
+  json.ipaddress @container[:data].ipaddress
+  json.image @container[:data].image
+  json.lxc_profiles @container[:data].lxc_profiles
+  json.created_at @container[:data].created_at
 end
 

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -9,6 +9,7 @@ test:
   SIDEKIQ_POLL_INTERVAL: 5
   SIDEKIQ_REDIS_URL: redis://localhost:6379
   WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS: 15
+  MAX_RETRY: 10
 
 development:
   RAILS_ENV: development

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -9,7 +9,6 @@ test:
   SIDEKIQ_POLL_INTERVAL: 5
   SIDEKIQ_REDIS_URL: redis://localhost:6379
   WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS: 15
-  MAX_RETRY: 10
 
 development:
   RAILS_ENV: development

--- a/lib/clients/lxd.rb
+++ b/lib/clients/lxd.rb
@@ -20,9 +20,10 @@ module Lxd
   def show_container(container_name)
     container_details = client.container(container_name)
     container_state = client.container_state(container_name)
-    ipaddress = container_state[:network][:eth0][:addresses].
-        select {|x| x[:family] == 'inet'}.
-        first[:address]
+    ipaddress = container_state&.network&.eth0&.addresses || []
+    ipaddress = ipaddress.
+      select {|x| x[:family] == 'inet'}.
+      first&.address
     Container.new(
         container_hostname: container_name,
         status: container_state[:status],

--- a/lib/clients/lxd.rb
+++ b/lib/clients/lxd.rb
@@ -20,7 +20,7 @@ module Lxd
   def show_container(container_name)
     begin
       container_details = client.container(container_name)
-    rescue Hyperkit::NotFound => error
+    rescue Hyperkit::Error => error
       return {success: false, error: error.as_json}
     end
     container_state = client.container_state(container_name)

--- a/spec/controllers/containers_controller_spec.rb
+++ b/spec/controllers/containers_controller_spec.rb
@@ -48,15 +48,16 @@ RSpec.describe ContainersController do
   describe 'GET#show' do
     context 'show container details' do
       let(:container) { Container.new(container_hostname: 'p-user-01',status: 'Running',ipaddress: '240.1.2.1',image: 'ubuntu',lxc_profiles: ['default'],created_at: '2018-03-26 17:48:26 +0530') }
+      let(:container_res) { { success: true, data: container}}
       before do
-        allow(Lxd).to receive(:show_container).with('p-user-service-01').and_return(container)
+        allow(Lxd).to receive(:show_container).with('p-user-service-01').and_return(container_res)
       end
       it 'should return all details of a container' do
         get :show, params: { container_hostname: 'p-user-service-01' }
-        expect(assigns(:container)).to eq(container)
+        expect(assigns(:container)).to eq(container_res)
       end
 
-      it 'should render json resposne' do
+      it 'should render json response' do
         get :show, params: { container_hostname: 'p-user-service-01', format: 'json' }
         expect(response).to be_success
       end

--- a/spec/jobs/start_container_spec.rb
+++ b/spec/jobs/start_container_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'sidekiq/testing'
-require 'spec_helper'
 
 RSpec.describe StartContainer do
   before(:each) do
@@ -29,44 +28,6 @@ RSpec.describe StartContainer do
       allow_any_instance_of(Hyperkit::Client).to receive(:container).with(container_name).and_return(container_details)
       expect_any_instance_of(Hyperkit::Client).to receive(:start_container).once
       StartContainer.new.perform(container_name)
-    end
-
-    it 'should not start container if wait time not elapsed' do
-      container_details = {:architecture => "x86_64",
-                           :devices => {},
-                           :ephemeral => false,
-                           :profiles => ['default'],
-                           :stateful => false,
-                           :description => '',
-                           :created_at => Time.now,
-                           :name => 'p-wallet-service-01',
-                           :status => 'Stopped',
-                           :status_code => 103,
-                           :last_used_at => Time.now}
-      allow_any_instance_of(Hyperkit::Client).to receive(:container).with(container_name).and_return(container_details)
-      expect_any_instance_of(Hyperkit::Client).not_to receive(:start_container)
-      expect {
-        StartContainer.new.perform(container_name)
-      }.to raise_error(message="Container p-wallet-service-01 is still being created")
-    end
-
-    it 'should not start container if it is already running' do
-      container_details = {:architecture => "x86_64",
-                           :devices => {},
-                           :ephemeral => false,
-                           :profiles => ['default'],
-                           :stateful => false,
-                           :description => '',
-                           :created_at => Time.now - 30,
-                           :name => 'p-wallet-service-01',
-                           :status => 'Running',
-                           :status_code => 103,
-                           :last_used_at => Time.now}
-      allow_any_instance_of(Hyperkit::Client).to receive(:container).with(container_name).and_return(container_details)
-      expect_any_instance_of(Hyperkit::Client).not_to receive(:start_container)
-      expect {
-        StartContainer.new.perform(container_name)
-      }.not_to raise_error
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,13 +6,26 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
-
+require 'vcr'
+require 'hyperkit'
 
 RSpec.configure do |config|
    config.use_transactional_fixtures = false
    config.infer_spec_type_from_file_location!
    config.include Devise::Test::ControllerHelpers, :type => :controller
    config.extend ControllerMacros, :type => :controller
+   VCR.configure do |c|
+    c.cassette_library_dir     = 'spec/cassettes'
+    c.hook_into                :webmock
+    c.default_cassette_options = { :record => :new_episodes }
+    c.allow_http_connections_when_no_cassette = true
+    c.configure_rspec_metadata!
+  end
+
+  lxd_client = Hyperkit::Client.new(api_endpoint: "https://172.16.33.33:8443", verify_ssl: false)
+  config.after(:each, delete_profile_after: true) do |example|
+    lxd_client.delete_profile(example.metadata[:profile_name])
+  end
 end
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 require 'vcr'
 require 'hyperkit'
+require 'json'
+require 'ostruct'
 
 RSpec.configure do |config|
    config.use_transactional_fixtures = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require 'vcr'
-require 'hyperkit'
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -27,17 +25,4 @@ RSpec.configure do |config|
   end
 
   Kernel.srand config.seed
-
-  VCR.configure do |c|
-    c.cassette_library_dir     = 'spec/cassettes'
-    c.hook_into                :webmock
-    c.default_cassette_options = { :record => :new_episodes }
-    c.allow_http_connections_when_no_cassette = true
-    c.configure_rspec_metadata!
-  end
-
-  lxd_client = Hyperkit::Client.new(api_endpoint: "https://172.16.33.33:8443", verify_ssl: false)
-  config.after(:each, delete_profile_after: true) do |example|
-    lxd_client.delete_profile(example.metadata[:profile_name])
-  end
 end


### PR DESCRIPTION
Hi, we found an issue when creating containers, some of the containers start with missing files or ip address. This issue is getting more frequent when sauron changes to async using sidekiq, because many containers can get created at once.

When we investigate, we found out that by default sauron use `auto_sync: false` parameter when instantiating the hyperkit client. This transfer the responsibility of handling container asynchronous operation to sauron, but sauron does not implement `wait_for_operation` command as described in documentation of hyperkit [here](https://github.com/jeffshantz/hyperkit#asynchronous-operations).

The documentation specifically stated that

> Any asynchronous calls you issue after setting auto_sync to false will immediately return an operation ID instead of blocking. To ensure that an operation is complete, you will need to call wait_for_operation

This PR introduces `wait_for_operation`, while also removing unnecessary sleep and conditions when creating containers. We found zero issues until now when creating containers.

TODO: we can also modify delete operation to use `wait_for_operation` and remove sleep completely.