### PR TITLE
Recreate functionality

### DIFF
--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -20,8 +20,18 @@ class ContainersController < ApplicationController
       return
     end
     response = Lxd.destroy_container(params[:container_hostname])
-    return redirect_to containers_path(lxd_host_ipaddress: params[:lxd_host_ipaddress]) if response[:success] == 'true'
-    render json: response, status: :internal_server_error
+    respond_to do |format|
+      if response[:success] == 'true'
+        format.html { redirect_to containers_path(lxd_host_ipaddress: params[:lxd_host_ipaddress]) }
+        format.json { render json: response }
+      else
+        format.html {
+          redirect_to containers_path(lxd_host_ipaddress: params[:lxd_host_ipaddress]),
+          :notice => response[:error]
+        }
+        format.json { render json: response, status: :internal_server_error }
+      end
+    end
   end
 
   def index

--- a/app/views/containers/show.html.erb
+++ b/app/views/containers/show.html.erb
@@ -5,17 +5,17 @@
 
 <dl class="dl-horizontal">
   <dt><strong><%= model_class.human_attribute_name(:hostname) %>:</strong></dt>
-  <dd><%= @container.container_hostname %></dd>
+  <dd><%= @container[:data]&.container_hostname %></dd>
   <dt><strong><%= model_class.human_attribute_name(:ipaddress) %>:</strong></dt>
-  <dd><%= @container.ipaddress %></dd>
+  <dd><%= @container[:data]&.ipaddress %></dd>
   <dt><strong><%= model_class.human_attribute_name(:image) %>:</strong></dt>
-  <dd><%= @container.image %></dd>
+  <dd><%= @container[:data]&.image %></dd>
   <dt><strong><%= model_class.human_attribute_name(:status) %>:</strong></dt>
-  <dd><%= @container.status %></dd>
+  <dd><%= @container[:data]&.status %></dd>
   <dt><strong><%= model_class.human_attribute_name(:created_at) %>:</strong></dt>
-  <dd><%= @container.created_at %></dd>
+  <dd><%= @container[:data]&.created_at %></dd>
   <dt><strong><%= model_class.human_attribute_name(:lxc_profiles) %>:</strong></dt>
-  <dd><%= @container.lxc_profiles %></dd>
+  <dd><%= @container[:data]&.lxc_profiles %></dd>
   <%= link_to t('.back', :default => t("helpers.links.back")),
     container_hosts_path(), :class => 'btn btn-primary btn-sm' %>
 </dl>

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -2,6 +2,7 @@ DB_HOST: localhost
 DB_USER: postgres
 DB_POOL: 10
 DB_PASSWORD:
+CLUSTER_TRUST_PASSWORD: ubuntu
 
 test:
   RAILS_ENV: test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get '/container-hosts/:id', to: 'container_hosts#show', as: 'container_host'
 
   post '/containers', to: 'containers#create', as: 'containers_create'
-  post '/recreate_container', to: 'containers#recreate', as: 'containers_recreate'
+  post '/containers/recreate', to: 'containers#recreate', as: 'containers_recreate'
   get '/containers', to: 'containers#index', as: 'containers'
   get '/container', to: 'containers#show', as: 'container'
   get '/containers/new', to: 'containers#new', as: 'containers_new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get '/container-hosts/:id', to: 'container_hosts#show', as: 'container_host'
 
   post '/containers', to: 'containers#create', as: 'containers_create'
+  post '/recreate_container', to: 'containers#recreate', as: 'containers_recreate'
   get '/containers', to: 'containers#index', as: 'containers'
   get '/container', to: 'containers#show', as: 'container'
   get '/containers/new', to: 'containers#new', as: 'containers_new'

--- a/lib/clients/lxd.rb
+++ b/lib/clients/lxd.rb
@@ -41,7 +41,7 @@ module Lxd
 
   #does not honour image param, will launch 16.04 by default for now.
   def launch_container(image, container_hostname)
-    create_container_response = Lxd.create_container(container_hostname)
+    create_container_response = create_container(container_hostname)
     if create_container_response[:success] == 'true'
       StartContainer.perform_async(container_hostname)
     end
@@ -70,8 +70,12 @@ module Lxd
   end
 
   def destroy_container(container_hostname)
-    stop_container_response = stop_container(container_hostname)
-    if stop_container_response[:success] == 'true'
+    show_res = show_container(container_hostname)
+    is_stopped = (show_res.dig(:data)&.status == "Stopped")
+    unless is_stopped
+      stop_container_response = stop_container(container_hostname)
+    end
+    if is_stopped || stop_container_response[:success] == 'true'
       DeleteContainer.perform_in(Figaro.env.WAIT_INTERVAL_FOR_CONTAINER_OPERATIONS, container_hostname)
     end
     stop_container_response
@@ -80,11 +84,14 @@ module Lxd
   def stop_container(container_hostname)
     begin
       response = client.stop_container(container_hostname)
+      op_response = client.wait_for_operation(response[:id])
     rescue Hyperkit::Error => error
       return {success: false, error: error.as_json}
     end
-    success = response[:status] == 'Running' ? 'true' : false
-    {success: success, error: response[:err]}
+    success = op_response[:status] == 'Success' ? 'true' : false
+    {success: success, error: op_response[:err]}
+  end
+
   end
 
   def attach_public_key(container_hostname, public_key, opts = {})

--- a/lib/clients/lxd.rb
+++ b/lib/clients/lxd.rb
@@ -5,7 +5,7 @@ module Lxd
   def add_remote(lxd_host_ipaddress)
     lxd = client(lxd_host_ipaddress)
     begin
-      lxd.create_certificate(File.read(lxd.client_cert), password: 'ubuntu')
+      lxd.create_certificate(File.read(lxd.client_cert), password: Figaro.env.CLUSTER_TRUST_PASSWORD)
     rescue StandardError => error
       return {success: false, errors: error.to_s} unless error.to_s.include? "Certificate already in trust store"
     end

--- a/spec/controllers/containers_controller_spec.rb
+++ b/spec/controllers/containers_controller_spec.rb
@@ -30,6 +30,36 @@ RSpec.describe ContainersController do
     end
   end
 
+  describe 'POST#recreate' do
+    before(:each) do
+      FactoryBot.create(:container_host)
+    end
+
+    context 'success' do
+      it 'should return successfull response if recreate_container success' do
+        allow(Lxd).to receive(:recreate_container).and_return({success: 'true'})
+        post :recreate , :params => {:container => {:container_hostname => 'p-user-service-01', image: 'ubuntu:16.04'}}
+        expect(response.code).to eq '201'
+      end
+    end
+
+    context 'failure' do
+      it 'should return 400 if supplied container is invalid' do
+        container = Container.new
+        allow(container).to receive(:valid?).and_return false
+        allow(Container).to receive(:new).and_return(container)
+        post :recreate , :params => {:container => {:container_hostname => 'p-user-service-01', image: 'ubuntu:16.04'}}
+        expect(response.code).to eq '400'
+      end
+
+      it 'should return successfull response if recreate_container success' do
+        allow(Lxd).to receive(:recreate_container).and_return({})
+        post :recreate , :params => {:container => {:container_hostname => 'p-user-service-01', image: 'ubuntu:16.04'}}
+        expect(response.code).to eq '500'
+      end
+    end
+  end
+
   describe 'GET#index' do
     context 'list all the containers of a host' do
       it 'should return all the hosts' do

--- a/spec/controllers/containers_controller_spec.rb
+++ b/spec/controllers/containers_controller_spec.rb
@@ -70,18 +70,28 @@ RSpec.describe ContainersController do
 
       it "should destroy a container based on hostname and host's ipaddress" do
         allow(Lxd).to receive(:destroy_container).with(container_hostname).and_return({success: 'true', error: ''})
-
         delete :destroy, params: {container_hostname: container_hostname}
         expect(response.code).to eq('302')
       end
 
-      it 'return errors if LXD moduld fails' do
+      it "should redirect if LXD module fails" do
         allow(Lxd).to receive(:destroy_container).with(container_hostname).and_return({success: 'false', error: 'bad request'})
-
         delete :destroy, params: {container_hostname: container_hostname}
-        expect(response.code).to eq('500')
-        expect(JSON.parse(response.body)['error']).to eq('bad request')
-        expect(JSON.parse(response.body)['success']).to eq('false')
+        expect(response.code).to eq('302')
+      end
+
+      context 'JSON request' do
+        before(:each) do
+          request.env["HTTP_ACCEPT"] = 'application/json'
+        end
+
+        it 'return errors if LXD module fails' do
+          allow(Lxd).to receive(:destroy_container).with(container_hostname).and_return({success: 'false', error: 'bad request'})
+          delete :destroy, params: {container_hostname: container_hostname}
+          expect(response.code).to eq('500')
+          expect(JSON.parse(response.body)['error']).to eq('bad request')
+          expect(JSON.parse(response.body)['success']).to eq('false')
+        end
       end
     end
 


### PR DESCRIPTION
We introduce a new API to `recreate` containers. This is usually done when we have broken containers and need to re-launch them. We create a specific function for this because the whole process (stopping, deleting, creating and starting) must be done atomically.

We also fix some issues when testing. Including adding more `wait_for_operation` to avoid race condition when doing some actions to the containers.